### PR TITLE
feature(store): add get_metadata and set_metadata methods to stores

### DIFF
--- a/src/zarr/v3/abc/store.py
+++ b/src/zarr/v3/abc/store.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 from collections.abc import AsyncGenerator
 
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Any
 
 
 class Store(ABC):
@@ -37,6 +37,20 @@ class Store(ABC):
         -------
         list[bytes]
             list of values, in the order of the key_ranges, may contain null/none for missing keys
+        """
+        ...
+
+    @abstractmethod
+    async def get_metadata(self, key: str) -> Optional[dict[str, Any]]:
+        """Retrieve the metadata associated with a given key.
+
+        Parameters
+        ----------
+        key : str
+
+        Returns
+        -------
+        bytes
         """
         ...
 
@@ -97,6 +111,17 @@ class Store(ABC):
             set of key, range_start, values triples, a key may occur multiple times with different
             range_starts, range_starts (considering the length of the respective values) must not
             specify overlapping ranges for the same key
+        """
+        ...
+
+    @abstractmethod
+    async def set_metadata(self, key: str, metadata: dict[str, Any]) -> None:
+        """Store metadata associated with a given key.
+
+        Parameters
+        ----------
+        key : str
+        metadata : dict
         """
         ...
 

--- a/src/zarr/v3/array.py
+++ b/src/zarr/v3/array.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 
-import json
 from typing import Any, Dict, Iterable, Literal, Optional, Tuple, Union
 
 import numpy as np
@@ -150,11 +149,11 @@ class AsyncArray:
         runtime_configuration: RuntimeConfiguration = RuntimeConfiguration(),
     ) -> AsyncArray:
         store_path = make_store_path(store)
-        zarr_json_bytes = await (store_path / ZARR_JSON).get()
-        assert zarr_json_bytes is not None
+        zarr_json = await (store_path / ZARR_JSON).get_metadata()
+        assert zarr_json is not None
         return cls.from_dict(
             store_path,
-            json.loads(zarr_json_bytes),
+            zarr_json,
             runtime_configuration=runtime_configuration,
         )
 
@@ -165,11 +164,11 @@ class AsyncArray:
         runtime_configuration: RuntimeConfiguration = RuntimeConfiguration(),
     ) -> AsyncArray:  # TODO: Union[AsyncArray, ArrayV2]
         store_path = make_store_path(store)
-        v3_metadata_bytes = await (store_path / ZARR_JSON).get()
-        if v3_metadata_bytes is not None:
+        v3_metadata = await (store_path / ZARR_JSON).get_metadata()
+        if v3_metadata is not None:
             return cls.from_dict(
                 store_path,
-                json.loads(v3_metadata_bytes),
+                v3_metadata,
                 runtime_configuration=runtime_configuration or RuntimeConfiguration(),
             )
         else:
@@ -227,7 +226,7 @@ class AsyncArray:
             return out[()]
 
     async def _save_metadata(self) -> None:
-        await (self.store_path / ZARR_JSON).set(self.metadata.to_bytes())
+        await (self.store_path / ZARR_JSON).set_metadata(self.metadata.to_dict())
 
     async def _read_chunk(
         self,
@@ -396,14 +395,14 @@ class AsyncArray:
         )
 
         # Write new metadata
-        await (self.store_path / ZARR_JSON).set(new_metadata.to_bytes())
+        await (self.store_path / ZARR_JSON).set_metadata(new_metadata.to_dict())
         return replace(self, metadata=new_metadata)
 
     async def update_attributes(self, new_attributes: Dict[str, Any]) -> AsyncArray:
         new_metadata = replace(self.metadata, attributes=new_attributes)
 
         # Write new metadata
-        await (self.store_path / ZARR_JSON).set(new_metadata.to_bytes())
+        await (self.store_path / ZARR_JSON).set_metadata(new_metadata.to_dict())
         return replace(self, metadata=new_metadata)
 
     def __repr__(self):

--- a/src/zarr/v3/metadata.py
+++ b/src/zarr/v3/metadata.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, cast, Dict, Iterable, Any
 from dataclasses import dataclass, field
-import json
 import numpy as np
 
 from zarr.v3.chunk_grids import ChunkGrid, RegularChunkGrid
@@ -193,23 +192,6 @@ class ArrayMetadata(Metadata):
             fill_value=self.fill_value,
         )
 
-    def to_bytes(self) -> bytes:
-        def _json_convert(o):
-            if isinstance(o, np.dtype):
-                return str(o)
-            if isinstance(o, Enum):
-                return o.name
-            # this serializes numcodecs compressors
-            # todo: implement to_dict for codecs
-            elif hasattr(o, "get_config"):
-                return o.get_config()
-            raise TypeError
-
-        return json.dumps(
-            self.to_dict(),
-            default=_json_convert,
-        ).encode()
-
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ArrayMetadata:
         # check that the zarr_format attribute is correct
@@ -289,17 +271,6 @@ class ArrayV2Metadata(Metadata):
     @property
     def ndim(self) -> int:
         return len(self.shape)
-
-    def to_bytes(self) -> bytes:
-        def _json_convert(o):
-            if isinstance(o, np.dtype):
-                if o.fields is None:
-                    return o.str
-                else:
-                    return o.descr
-            raise TypeError
-
-        return json.dumps(self.to_dict(), default=_json_convert).encode()
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> ArrayV2Metadata:

--- a/src/zarr/v3/store/core.py
+++ b/src/zarr/v3/store/core.py
@@ -30,10 +30,16 @@ class StorePath:
     ) -> Optional[BytesLike]:
         return await self.store.get(self.path, byte_range)
 
+    async def get_metadata(self) -> Optional[dict[str, Any]]:
+        return await self.store.get_metadata(self.path)
+
     async def set(self, value: BytesLike, byte_range: Optional[Tuple[int, int]] = None) -> None:
         if byte_range is not None:
             raise NotImplementedError("Store.set does not have partial writes yet")
         await self.store.set(self.path, value)
+
+    async def set_metadata(self, metadata: dict[str, Any]) -> None:
+        await self.store.set_metadata(self.path, metadata)
 
     async def delete(self) -> None:
         await self.store.delete(self.path)

--- a/src/zarr/v3/store/local.py
+++ b/src/zarr/v3/store/local.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Union, Optional, List, Tuple
 
 from zarr.v3.abc.store import Store
+from zarr.v3.store.mixins import JsonMetadataStoreMixin
 from zarr.v3.common import BytesLike, concurrent_map, to_thread
 
 
@@ -64,7 +65,7 @@ def _put(
         return path.write_bytes(value)
 
 
-class LocalStore(Store):
+class LocalStore(JsonMetadataStoreMixin, Store):
     supports_writes: bool = True
     supports_partial_writes: bool = True
     supports_listing: bool = True
@@ -157,7 +158,6 @@ class LocalStore(Store):
             if p.is_file():
                 yield str(p)
 
-
     async def list_prefix(self, prefix: str) -> AsyncGenerator[str, None]:
         """Retrieve all keys in the store with a given prefix.
 
@@ -172,7 +172,6 @@ class LocalStore(Store):
         for p in (self.root / prefix).rglob("*"):
             if p.is_file():
                 yield str(p)
-
 
     async def list_dir(self, prefix: str) -> AsyncGenerator[str, None]:
         """
@@ -189,7 +188,7 @@ class LocalStore(Store):
         """
         base = self.root / prefix
         to_strip = str(base) + "/"
-        
+
         try:
             key_iter = base.iterdir()
         except (FileNotFoundError, NotADirectoryError):
@@ -197,4 +196,3 @@ class LocalStore(Store):
 
         for key in key_iter:
             yield str(key).replace(to_strip, "")
-

--- a/src/zarr/v3/store/memory.py
+++ b/src/zarr/v3/store/memory.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import Optional, MutableMapping, List, Tuple
+from typing import Any, Optional, MutableMapping, List, Tuple
 
 from zarr.v3.common import BytesLike
 from zarr.v3.abc.store import Store
 
 
-# TODO: this store could easily be extended to wrap any MutuableMapping store from v2
-# When that is done, the `MemoryStore` will just be a store that wraps a dict.
 class MemoryStore(Store):
     supports_writes: bool = True
     supports_partial_writes: bool = True
@@ -37,6 +35,12 @@ class MemoryStore(Store):
         except KeyError:
             return None
 
+    async def get_metadata(self, key: str) -> Optional[dict[str, Any]]:
+        try:
+            return self._store_dict[key]
+        except KeyError:
+            return None
+
     async def get_partial_values(
         self, key_ranges: List[Tuple[str, Tuple[int, int]]]
     ) -> List[bytes]:
@@ -58,6 +62,9 @@ class MemoryStore(Store):
             self._store_dict[key] = buf
         else:
             self._store_dict[key] = value
+
+    async def set_metadata(self, key: str, metadata: dict[str, Any]) -> None:
+        self._store_dict[key] = metadata
 
     async def delete(self, key: str) -> None:
         try:

--- a/src/zarr/v3/store/mixins.py
+++ b/src/zarr/v3/store/mixins.py
@@ -1,0 +1,39 @@
+import json
+import numbers
+from enum import Enum
+from typing import Any, Optional
+
+import numpy as np
+
+
+def json_default(o: Any) -> Any:
+    # See json.JSONEncoder.default docstring for explanation
+    # This is necessary to encode numpy dtype
+    if isinstance(o, numbers.Integral):
+        return int(o)
+    if isinstance(o, numbers.Real):
+        return float(o)
+    if isinstance(o, np.dtype):
+        if o.fields is None:
+            return o.str
+        else:
+            return o.descr
+    if isinstance(o, Enum):
+        return o.name
+    # this serializes numcodecs compressors
+    # todo: implement to_dict for codecs
+    elif hasattr(o, "get_config"):
+        return o.get_config()
+    raise TypeError
+
+
+class JsonMetadataStoreMixin:
+    async def get_metadata(self, key: str) -> Optional[dict[str, Any]]:
+        data = await self.get(key)
+        if data is None:
+            return None
+        return json.loads(data)
+
+    async def set_metadata(self, key: str, metadata: dict[str, Any]) -> None:
+        data = json.dumps(metadata, default=json_default).encode("utf-8")
+        await self.set(key, data)

--- a/tests/v3/test_codecs.py
+++ b/tests/v3/test_codecs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
 
-import json
 from typing import Iterator, List, Literal, Optional, Tuple
 
 
@@ -21,6 +20,7 @@ from zarr.v3.codecs import (
     TransposeCodec,
     ZstdCodec,
 )
+from zarr.v3.codecs.blosc import BloscShuffle
 from zarr.v3.metadata import runtime_configuration
 
 from zarr.v3.abc.store import Store
@@ -738,9 +738,9 @@ async def test_dimension_names(store: Store):
     )
 
     assert (await AsyncArray.open(store / "dimension_names2")).metadata.dimension_names is None
-    zarr_json_bytes = await (store / "dimension_names2" / "zarr.json").get()
-    assert zarr_json_bytes is not None
-    assert "dimension_names" not in json.loads(zarr_json_bytes)
+    zarr_json = await (store / "dimension_names2" / "zarr.json").get_metadata()
+    assert zarr_json is not None
+    assert "dimension_names" not in zarr_json
 
 
 def test_gzip(store: Store):
@@ -966,10 +966,10 @@ async def test_blosc_evolve(store: Store):
         codecs=[BytesCodec(), BloscCodec()],
     )
 
-    zarr_json = json.loads(await (store / "blosc_evolve_u1" / "zarr.json").get())
+    zarr_json = await (store / "blosc_evolve_u1" / "zarr.json").get_metadata()
     blosc_configuration_json = zarr_json["codecs"][1]["configuration"]
     assert blosc_configuration_json["typesize"] == 1
-    assert blosc_configuration_json["shuffle"] == "bitshuffle"
+    assert blosc_configuration_json["shuffle"] == BloscShuffle.bitshuffle
 
     await AsyncArray.create(
         store / "blosc_evolve_u2",
@@ -980,10 +980,10 @@ async def test_blosc_evolve(store: Store):
         codecs=[BytesCodec(), BloscCodec()],
     )
 
-    zarr_json = json.loads(await (store / "blosc_evolve_u2" / "zarr.json").get())
+    zarr_json = await (store / "blosc_evolve_u2" / "zarr.json").get_metadata()
     blosc_configuration_json = zarr_json["codecs"][1]["configuration"]
     assert blosc_configuration_json["typesize"] == 2
-    assert blosc_configuration_json["shuffle"] == "shuffle"
+    assert blosc_configuration_json["shuffle"] == BloscShuffle.shuffle
 
     await AsyncArray.create(
         store / "sharding_blosc_evolve",
@@ -994,10 +994,10 @@ async def test_blosc_evolve(store: Store):
         codecs=[ShardingCodec(chunk_shape=(16, 16), codecs=[BytesCodec(), BloscCodec()])],
     )
 
-    zarr_json = json.loads(await (store / "sharding_blosc_evolve" / "zarr.json").get())
+    zarr_json = await (store / "sharding_blosc_evolve" / "zarr.json").get_metadata()
     blosc_configuration_json = zarr_json["codecs"][0]["configuration"]["codecs"][1]["configuration"]
     assert blosc_configuration_json["typesize"] == 2
-    assert blosc_configuration_json["shuffle"] == "shuffle"
+    assert blosc_configuration_json["shuffle"] == BloscShuffle.shuffle
 
 
 def test_exists_ok(store: Store):


### PR DESCRIPTION
This is pointing at @d-v-b's fork because I branched of `v3_group_tests`. Once that PR goes in, I'll set the target to the zarr-python v3 branch.

Description: This PR adds two new methods to the v3 Store API (`get_metadata` and `set_metadata`). For most stores, this means that JSON serialization now happens in the Store. Crucially, this unlocks the ability for some stores to keep metadata in a container other than JSON (e.g. in a database that natively stores dictionaries). 

Xref: https://github.com/zarr-developers/zarr-python/discussions/1686#discussioncomment-8620738

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
