### PR TITLE
test(stores): provide public store test class

### DIFF
--- a/src/zarr/v3/group.py
+++ b/src/zarr/v3/group.py
@@ -310,7 +310,7 @@ class AsyncGroup:
             # and scoped to specific zarr versions
             if key not in ("zarr.json", ".zgroup", ".zattrs"):
                 try:
-                    # TODO: performance optimization -- load children concurrently   
+                    # TODO: performance optimization -- load children concurrently
                     child = await self.getitem(key)
                     yield key, child
                 except KeyError:

--- a/src/zarr/v3/store/local.py
+++ b/src/zarr/v3/store/local.py
@@ -157,7 +157,6 @@ class LocalStore(Store):
             if p.is_file():
                 yield str(p)
 
-
     async def list_prefix(self, prefix: str) -> AsyncGenerator[str, None]:
         """Retrieve all keys in the store with a given prefix.
 
@@ -172,7 +171,6 @@ class LocalStore(Store):
         for p in (self.root / prefix).rglob("*"):
             if p.is_file():
                 yield str(p)
-
 
     async def list_dir(self, prefix: str) -> AsyncGenerator[str, None]:
         """
@@ -189,7 +187,7 @@ class LocalStore(Store):
         """
         base = self.root / prefix
         to_strip = str(base) + "/"
-        
+
         try:
             key_iter = base.iterdir()
         except (FileNotFoundError, NotADirectoryError):
@@ -197,4 +195,3 @@ class LocalStore(Store):
 
         for key in key_iter:
             yield str(key).replace(to_strip, "")
-

--- a/src/zarr/v3/store/memory.py
+++ b/src/zarr/v3/store/memory.py
@@ -40,7 +40,7 @@ class MemoryStore(Store):
     async def get_partial_values(
         self, key_ranges: List[Tuple[str, Tuple[int, int]]]
     ) -> List[bytes]:
-        raise NotImplementedError
+        return [await self.get(key, range) for key, range in key_ranges]
 
     async def exists(self, key: str) -> bool:
         return key in self._store_dict

--- a/src/zarr/v3/testing/store.py
+++ b/src/zarr/v3/testing/store.py
@@ -1,0 +1,46 @@
+import pytest
+
+from zarr.v3.abc.store import Store
+
+
+class StoreTests:
+    store_cls: type[Store]
+
+    @pytest.fixture(scope="function")
+    def store(self) -> Store:
+        return self.store_cls()
+
+    def test_store_type(self, store: Store) -> None:
+        assert isinstance(store, Store)
+        assert isinstance(store, self.store_cls)
+
+    def test_store_repr(self, store: Store) -> None:
+        assert repr(store)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("key", ["c/0", "foo/c/0.0", "foo/0/0"])
+    @pytest.mark.parametrize("data", [b"\x01\x02\x03\x04", b""])
+    async def test_set_get_bytes_roundtrip(self, store: Store, key: str, data: bytes) -> None:
+        await store.set(key, data)
+        assert await store.get(key) == data
+
+    # @pytest.mark.parametrize("key, data, error, error_msg", [
+    #     ("", b"\x01\x02\x03\x04", ValueError, "invalid key")
+    # ])
+    # async def test_set_raises(self, store, key: Any, data: Any) -> None:
+    #     with pytest.raises(TypeError):
+    #         await store.set(key, data)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("key", ["foo/c/0"])
+    @pytest.mark.parametrize("data", [b"\x01\x02\x03\x04", b""])
+    async def test_get_partial_values(self, store: Store, key: str, data: bytes) -> None:
+        # put all of the data
+        await store.set(key, data)
+        # read back just part of it
+        vals = await store.get_partial_values([(key, (0, 2))])
+        assert vals == [data[0:2]]
+
+        # read back multiple parts of it at once
+        vals = await store.get_partial_values([(key, (0, 2)), (key, (2, 4))])
+        assert vals == [data[0:2], data[2:4]]

--- a/tests/v3/test_storage.py
+++ b/tests/v3/test_storage.py
@@ -7,9 +7,23 @@
 
 # import numpy as np
 from __future__ import annotations
+from zarr.v3.testing.store import StoreTests
 from zarr.v3.store.local import LocalStore
+from zarr.v3.store.memory import MemoryStore
 from pathlib import Path
 import pytest
+
+
+class TestLocalStore(StoreTests):
+    store_cls = LocalStore
+
+    @pytest.fixture(scope="function")
+    def store(self, tmpdir) -> LocalStore:
+        return self.store_cls(str(tmpdir))
+
+
+class TestMemoryStore(StoreTests):
+    store_cls = MemoryStore
 
 
 @pytest.mark.parametrize("auto_mkdir", (True, False))


### PR DESCRIPTION
Sharing a quick demo of the public store api idea I mentioned on our call this week. If you think this makes sense, I can fill it out further. 

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in docs/tutorial.rst
* [ ] Changes documented in docs/release.rst
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
