### PR TITLE
perf: memoize encoded inner chunk for scalar complete-shard writes

### DIFF
--- a/src/zarr/codecs/sharding.py
+++ b/src/zarr/codecs/sharding.py
@@ -725,7 +725,37 @@ class ShardingCodec(
                 shard_dict = dict.fromkeys(morton_order_iter(chunks_per_shard))
 
         # Merge, encode, and store each affected inner chunk into shard_dict.
+        #
+        # Scalar fast path: when the written value is a scalar broadcast, every
+        # *complete* inner chunk is byte-for-byte identical — same fill, same
+        # empty-check, same encoded bytes. Compute that outcome once and reuse it
+        # for all complete chunks instead of re-merging, re-checking, and
+        # re-encoding tens of thousands of identical chunks. Incomplete (edge)
+        # chunks still merge against their own existing data individually.
+        # `_sentinel` distinguishes "not computed yet" from a memoized `None`
+        # (an empty chunk).
+        _sentinel = object()
+        scalar_complete_result: Buffer | None | object = _sentinel
+
         for chunk_coords, chunk_sel, out_sel, is_complete_chunk in indexer:
+            if is_scalar and is_complete_chunk:
+                if scalar_complete_result is _sentinel:
+                    chunk_array = chunk_spec.prototype.nd_buffer.create(
+                        shape=self.chunk_shape,
+                        dtype=shard_spec.dtype.to_native_dtype(),
+                        order=shard_spec.order,
+                        fill_value=fill_value,
+                    )
+                    chunk_array[chunk_sel] = value
+                    if skip_empty and chunk_array.all_equal(fill_value):
+                        scalar_complete_result = None
+                    else:
+                        scalar_complete_result = inner_transform.encode_chunk(
+                            chunk_array, chunk_spec
+                        )
+                shard_dict[chunk_coords] = scalar_complete_result  # type: ignore[assignment]
+                continue
+
             chunk_value = value if is_scalar else value[out_sel]
 
             if is_complete_chunk and not is_scalar:


### PR DESCRIPTION
In ShardingCodec._encode_partial_sync's full-shard-rewrite loop, a scalar broadcast value produces byte-for-byte identical results for every complete inner chunk (same fill, same empty-check, same encoded bytes). Compute that outcome once and reuse it across all complete chunks instead of re-merging, re-checking write_empty_chunks, and re-encoding tens of thousands of identical chunks. Incomplete edge chunks still merge against their own data individually.

Target case (fused, memory, chunks=100/shards=1M, no compression): write 92.26ms -> 21.59ms (4.3x). Pipeline parity (byte-identical to batched) and 956 tests pass under the fused pipeline; adversarial partial-overwrite/ edge/compression/2D/aliasing checks pass.

[Description of PR]

TODO:
* [ ] Add unit tests and/or doctests in docstrings
* [ ] Add docstrings and API docs for any new/modified user-facing classes and functions
* [ ] New/modified features documented in `docs/user-guide/*.md`
* [ ] Changes documented as a new file in `changes/`
* [ ] GitHub Actions have all passed
* [ ] Test coverage is 100% (Codecov passes)
